### PR TITLE
BUGFIX: contrast comparison from > to >=

### DIFF
--- a/src/rules/QW-ACT-R37.ts
+++ b/src/rules/QW-ACT-R37.ts
@@ -426,7 +426,7 @@ class QW_ACT_R37 extends AtomicRule {
     const isSmallFont = (isBold && parseFloat(fontSize) < 18.6667) || (!isBold && parseFloat(fontSize) < 24);
     const expectedContrastRatio = isSmallFont ? 4.5 : 3;
 
-    return contrast > expectedContrastRatio;
+    return contrast >= expectedContrastRatio;
   }
 
   getTextSize(font: string, fontSize: number, bold: boolean, italic: boolean, text: string): number {

--- a/src/rules/QW-ACT-R76.ts
+++ b/src/rules/QW-ACT-R76.ts
@@ -426,7 +426,7 @@ class QW_ACT_R76 extends AtomicRule {
     const isSmallFont = (isBold && parseFloat(fontSize) < 18.6667) || (!isBold && parseFloat(fontSize) < 24);
     const expectedContrastRatio = isSmallFont ? 7 : 4.5;
 
-    return contrast > expectedContrastRatio;
+    return contrast >= expectedContrastRatio;
   }
 
   getTextSize(font: string, fontSize: number, bold: boolean, italic: boolean, text: string): number {


### PR DESCRIPTION
"...has a contrast ratio of AT LEAST 4.5:1" and
"...has a contrast ratio of AT LEAST 7:1"