### PR TITLE
WCAG2 success criterion 1.4.4 is 'AA', not 'A'

### DIFF
--- a/src/lib/rules.json
+++ b/src/lib/rules.json
@@ -972,7 +972,7 @@
       "success-criteria": [
         {
           "name": "1.4.4",
-          "level": "A",
+          "level": "AA",
           "principle": "Perceivable",
           "url": "https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html",
 		      "url_tr": "https://www.w3.org/TR/WCAG21/#resize-text"


### PR DESCRIPTION
As both per WCAG 2.0 and WCAG 2.1 specification, success criterion 1.4.4 is of level 'AA', not 'A'.

https://www.w3.org/TR/WCAG20/#visual-audio-contrast
https://www.w3.org/TR/WCAG21/#resize-text